### PR TITLE
HTTPExceptions where status_code is fastapi.status

### DIFF
--- a/fastapi_responses/utils.py
+++ b/fastapi_responses/utils.py
@@ -6,6 +6,7 @@ from io import BytesIO
 from tokenize import TokenInfo
 from typing import Callable, Generator, List, Tuple
 
+from fastapi import status
 from fastapi.routing import APIRoute
 from starlette.exceptions import HTTPException
 


### PR DESCRIPTION
fastapi HTTPExceptions support fastapi.status codes as legit status_code values. [Example](https://fastapi.tiangolo.com/advanced/response-change-status-code/#use-a-response-parameter). If an HTTPException contains such a status_code, the eval(statement) in exceptions_functions failed and the exception is not recorded. This is an attempt to enable that behavior.